### PR TITLE
[pulsar-function] New Pulsar function metrics implementation for supporting tracking a broader types of metrics.

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/BaseContext.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/BaseContext.java
@@ -24,6 +24,7 @@ import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
+import org.apache.pulsar.functions.api.metrics.MetricProvider;
 import org.slf4j.Logger;
 
 /**
@@ -188,10 +189,18 @@ public interface BaseContext {
 
     /**
      * Record a user defined metric.
+     * Deprecated, please use metricProvider().
      * @param metricName The name of the metric
      * @param value The value of the metric
      */
+    @Deprecated
     void recordMetric(String metricName, double value);
+
+    /**
+     * Returns {@code MetricProvider} to register or create new metrics.
+     * @return {@code MetricProvider}
+     */
+    MetricProvider metricProvider();
 
     /**
      * Get the pre-configured pulsar client.

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/Counter.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/Counter.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+/**
+ * A Counter is a {@link Metric} that measures a count. A counter's value can only increase. If you need a metric value
+ * that can both increase and decrease, please see {@link Gauge}
+ */
+public interface Counter extends Metric {
+
+    /**
+     * Increment the value of the counter by 1.
+     */
+    void inc();
+
+    /**
+     * Increment the value of the counter by an amount.
+     * @param amount the amount to increment the counter
+     */
+    void inc(double amount);
+
+    /**
+     * Get the current value of the counter.
+     * @return the value of the counter
+     */
+    double get();
+
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/CounterBuilder.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/CounterBuilder.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+/**
+ * Interface for building a {@link Counter} metric to register. The caller can optionally provide an external counter to
+ * register. If no counter is provided, a default counter implementation will be built and returned for use.
+ */
+public interface CounterBuilder extends MetricBuilder<CounterBuilder, Counter> {
+
+    /**
+     * Optionally supply a counter metric to register. If no counter is provided, a default implementation will be used.
+     * @param metric the counter to register
+     * @return {@code CounterBuilder}
+     */
+    CounterBuilder counter(Counter metric);
+
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/Gauge.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/Gauge.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+/**
+ * A gauge is a {@link Metric} that measures a count. A gauge's value can both increase and decrease
+ */
+public interface Gauge extends Metric {
+
+    /**
+     * Increment the value of the gauge by 1.
+     */
+    void inc();
+
+    /**
+     * Increment the value of the gauge by an amount.
+     * @param amount the amount to increment the gauge
+     */
+    void inc(double amount);
+
+    /**
+     * Decrement the value of the gauge by 1.
+     */
+    void dec();
+
+    /**
+     * Decrement the value of the gauge by an amount.
+     * @param amount the amount to decrement the gauge
+     */
+    void dec(double amount);
+
+    /**
+     * Set the value of the gauge to a specific amount.
+     * @param amount the amount to set the gauge's value to
+     */
+    void set(double amount);
+
+    /**
+     * Get the current value of the gauge.
+     * @return the current value of the gauge
+     */
+    double get();
+
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/GaugeBuilder.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/GaugeBuilder.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+/**
+ * Interface for building a {@link Gauge} metric to register. The caller can optionally provide an external gauge to
+ * register. If no gauge is provided, a default gauge implementation will be built and returned for use.
+ */
+public interface GaugeBuilder extends MetricBuilder<GaugeBuilder, Gauge> {
+
+    /**
+     * Optionally supply a gauge metric to register. If no gauge is provided, a default implementation will be used.
+     * @param gauge the gauge to register
+     * @return {@code GaugeBuilder}
+     */
+    GaugeBuilder gauge(Gauge gauge);
+
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/Histogram.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/Histogram.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+/**
+ * A histogram is a {@link Metric} for tracking distribution of events.
+ */
+public interface Histogram extends Metric {
+
+    /**
+     * Observe the given value.
+     * @param value the value to observe
+     */
+    void observe(double value);
+
+    /**
+     * Get the buckets used by this histogram.
+     * @return buckets
+     */
+    double[] getBuckets();
+
+    /**
+     * Get the count values for each bucket.
+     * @return bucket values
+     */
+    double[] getValues();
+
+    /**
+     * Get the current total sum of all observed value.
+     * @return sum of observed value
+     */
+    double getSum();
+
+    /**
+     * Get the total count of observations.
+     * @return total count of observations.
+     */
+    double getCount();
+
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/HistogramBuilder.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/HistogramBuilder.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+/**
+ * Interface for building a {@link histogram} metric to register. The caller can optionally provide an external
+ * histogram to register. If no histogram is provided, a default histogram implementation will be built and returned
+ * for use. A bucket list is required if no histogram is provided to the builder.
+ */
+public interface HistogramBuilder extends MetricBuilder<HistogramBuilder, Histogram> {
+
+    /**
+     * Optionally supply a buckets array for the histogram to use. If no buckets are provided, a histogram to register
+     * must be provided. One of buckets or histogram must be provided.
+     * @param buckets buckets the histogram should use
+     * @return {@code HistogramBuilder}
+     */
+    HistogramBuilder buckets(double[] buckets);
+
+    /**
+     * Optionally supply a histogram metric to register. If no histogram is provided, a default implementation will be
+     * used. If a histogram is provided, the buckets set will be ignored. One of buckets or histogram must be provided.
+     * @param histogram the histogram metric to register
+     * @return {@code HistogramBuilder}
+     */
+    HistogramBuilder histogram(Histogram histogram);
+
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/Metric.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/Metric.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+/**
+ * Common super interface for all metrics.
+ */
+public interface Metric {
+
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/MetricBuilder.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/MetricBuilder.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+/**
+ * Common super interface for all metric builders.
+ * @param <T> type for the metric builder
+ * @param <V> type for the metric to build
+ */
+public interface MetricBuilder<T extends MetricBuilder<T, V>, V extends Metric> {
+
+    /**
+     * Provide a name to the metric to build.
+     * @param metricName the name for the metric
+     * @return this builder
+     */
+    T name(String metricName);
+
+    /**
+     * Provide label names to the metric to build.
+     * @param labelNames names of the labels for the metric
+     * @return this builder
+     */
+    T labelNames(String... labelNames);
+
+    /**
+     * Provide label values to the metric to build.
+     * @param labels label values for the metric
+     * @return this builder
+     */
+    T labels(String... labels);
+
+    /**
+     * Provide a help message for the metric.
+     * @param helpMsg help message for the metric
+     * @return this builder
+     */
+    T help(String helpMsg);
+
+    /**
+     * Register the built metric to the framework.
+     * @return this builder
+     */
+    V register();
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/MetricProvider.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/MetricProvider.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+/**
+ * Metric provider interface for registering metrics. Each registration method returns a metric builder for building
+ * and registering metrics.
+ */
+public interface MetricProvider {
+
+    /**
+     * Return a builder for the Counter metric for building and registering.
+     * @return builder for the Counter metric
+     */
+    CounterBuilder registerCounter();
+
+    /**
+     * Return a builder for the Gauge metric for building and registering.
+     * @return builder for the Gauge metric
+     */
+    GaugeBuilder registerGauge();
+
+    /**
+     * Return a builder for the Histogram metric for building and registering.
+     * @return builder for the Histogram metric
+     */
+    HistogramBuilder registerHistogram();
+
+    /**
+     * Return a builder for the Summary metric for building and registering.
+     * @return builder for the Summary metric
+     */
+    SummaryBuilder registerSummary();
+
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/Summary.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/Summary.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * A Summary is a {@link Metric} for tracking the size of events.
+ */
+public interface Summary extends Metric {
+
+    /**
+     * Observe the given amount.
+     * @param amount the amount to observe
+     */
+    void observe(double amount);
+
+    /**
+     * Get the current total sum of all observed value.
+     * @return sum of observed value
+     */
+    double getSum();
+
+    /**
+     * Get the total count of observations.
+     * @return total count of observations.
+     */
+    double getCount();
+
+    /**
+     * Get the quantiles for the size of events.
+     * @return the quantiles for the events.
+     */
+    List<Quantile> getQuantiles();
+
+    /**
+     * Get the quantiles and values for each quantile. The keys of the Map are the quantiles of the Summary and the
+     * values are the corresponding quantile values.
+     * @return
+     */
+    Map<Double, Double> getQuantileValues();
+
+    /**
+     * Container class for Summary quantile and error.
+     */
+    @Data
+    @AllArgsConstructor(staticName = "of")
+    class Quantile {
+        private final double quantile;
+        private final double error;
+    }
+
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/SummaryBuilder.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/SummaryBuilder.java
@@ -34,7 +34,7 @@ public interface SummaryBuilder extends MetricBuilder<SummaryBuilder, Summary> {
     SummaryBuilder quantile(double quantile, double error);
 
     /**
-     * Optionally supply a summary metric to register. If no histogram is provided, a default implementation will be
+     * Optionally supply a summary metric to register. If no summary is provided, a default implementation will be
      * used. If a summary is provided, the quantiles and errors added will be ignored.
      * @param summary the summary metric to register
      * @return {@code SummaryBuilder}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/SummaryBuilder.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/SummaryBuilder.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.api.metrics;
+
+/**
+ * Interface for building a {@link Summary} metric to register. The caller can optionally provide an external Summary to
+ * register. If no Summary is provided, a default Summary implementation will be built and returned for use.
+ */
+public interface SummaryBuilder extends MetricBuilder<SummaryBuilder, Summary> {
+
+    /**
+     * Add quantile and error to the summary.
+     * @param quantile summary quantile
+     * @param error quantile error
+     * @return {@code SummaryBuilder}
+     */
+    SummaryBuilder quantile(double quantile, double error);
+
+    /**
+     * Optionally supply a summary metric to register. If no histogram is provided, a default implementation will be
+     * used. If a summary is provided, the quantiles and errors added will be ignored.
+     * @param summary the summary metric to register
+     * @return {@code SummaryBuilder}
+     */
+    SummaryBuilder summary(Summary summary);
+
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/package-info.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/metrics/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Provides an interface for pulsar functions to record metrics.
+ */
+package org.apache.pulsar.functions.api.metrics;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/MetricLabels.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/MetricLabels.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import com.google.common.collect.ObjectArrays;
+
+/**
+ * Interface for some common label operations.
+ */
+public interface MetricLabels {
+
+    default String[] combineLabels(String[] labels1, String[] labels2) {
+        if (labels1 == null || labels2 == null) {
+            return labels1 == null ? labels2 : labels1;
+        }
+        return ObjectArrays.concat(labels1, labels2, String.class);
+    }
+
+    default void checkLabels(String[] labelNames, String[] labels) {
+        checkArgument((labelNames == null) == (labels == null),
+                "Label names and labels must be both provided or both absent");
+
+        if (labelNames != null) {
+            checkArgument(labelNames.length == labels.length,
+                    "The number of label names need to match the number of labels");
+        }
+    }
+
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusCounterBuilder.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusCounterBuilder.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import io.prometheus.client.CollectorRegistry;
+import java.util.Arrays;
+import org.apache.pulsar.functions.api.metrics.Counter;
+import org.apache.pulsar.functions.api.metrics.CounterBuilder;
+
+public class PrometheusCounterBuilder implements CounterBuilder, MetricLabels {
+
+    private final CollectorRegistry collectorRegistry;
+    private final String customMetricNamePrefix;
+    private final String[] systemMetricsLabelNames;
+    private final String[] systemMetricsLabels;
+
+    private String metricName;
+    private String[] userDefinedLabels;
+    private String[] userDefinedLabelNames;
+    private String helpMsg;
+
+    private Counter counter;
+
+    PrometheusCounterBuilder(CollectorRegistry collectorRegistry,
+                             String customMetricNamePrefix,
+                             String[] systemMetricsLabelNames,
+                             String[] systemMetricsLabels) {
+        this.collectorRegistry = collectorRegistry;
+        this.customMetricNamePrefix = customMetricNamePrefix;
+        this.systemMetricsLabelNames = Arrays.copyOf(systemMetricsLabelNames, systemMetricsLabelNames.length);
+        this.systemMetricsLabels = Arrays.copyOf(systemMetricsLabels, systemMetricsLabels.length);
+    }
+
+    @Override
+    public CounterBuilder name(String metricName) {
+        this.metricName = metricName;
+        return this;
+    }
+
+    @Override
+    public CounterBuilder labelNames(String... labelNames) {
+        this.userDefinedLabelNames = labelNames;
+        return this;
+    }
+
+    @Override
+    public CounterBuilder labels(String... labels) {
+        this.userDefinedLabels = labels;
+        return this;
+    }
+
+    @Override
+    public CounterBuilder help(String helpMsg) {
+        this.helpMsg = helpMsg;
+        return this;
+    }
+
+    @Override
+    public CounterBuilder counter(Counter counter) {
+        this.counter = counter;
+        return this;
+    }
+
+    @Override
+    public Counter register() {
+        checkArgument(this.metricName != null, "Metric name has not been set");
+        checkArgument(this.helpMsg != null, "Metric help message has not been set");
+        String[] labelNames = combineLabels(systemMetricsLabelNames, userDefinedLabelNames);
+        String[] labels = combineLabels(systemMetricsLabels, userDefinedLabels);
+        checkLabels(labelNames, labels);
+        Counter counter = getCounter();
+
+        io.prometheus.client.Counter counterCollector = createCounterCollector(
+                this.customMetricNamePrefix + metricName, labelNames, helpMsg);
+        collectorRegistry.register(counterCollector);
+        // needs to setChild because Prometheus collector implementation only collects metrics through a metric Child
+        counterCollector.setChild(new io.prometheus.client.Counter.Child() {
+            @Override
+            public double get() {
+                return counter.get();
+            }
+        }, labels);
+        return counter;
+    }
+
+    private Counter getCounter() {
+        if (counter == null) {
+            return new PrometheusCounterImpl(customMetricNamePrefix + metricName, helpMsg);
+        } else {
+            return counter;
+        }
+    }
+
+    private io.prometheus.client.Counter createCounterCollector(String name, String[] labelNames, String helpMsg) {
+        return io.prometheus.client.Counter.build()
+                .name(name)
+                .labelNames(labelNames)
+                .help(helpMsg)
+                .create();
+    }
+
+
+
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusCounterImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusCounterImpl.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import org.apache.pulsar.functions.api.metrics.Counter;
+
+public class PrometheusCounterImpl implements Counter {
+
+    private final io.prometheus.client.Counter counter;
+
+    PrometheusCounterImpl(String name, String helpMessage) {
+        this.counter = io.prometheus.client.Counter.build().name(name).help(helpMessage).create();
+    }
+
+    @Override
+    public void inc() {
+        this.counter.inc();
+    }
+
+    @Override
+    public void inc(double amount) {
+        this.counter.inc(amount);
+    }
+
+    @Override
+    public double get() {
+        return this.counter.get();
+    }
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusGaugeBuilder.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusGaugeBuilder.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import io.prometheus.client.CollectorRegistry;
+import java.util.Arrays;
+import org.apache.pulsar.functions.api.metrics.Gauge;
+import org.apache.pulsar.functions.api.metrics.GaugeBuilder;
+
+public class PrometheusGaugeBuilder implements GaugeBuilder, MetricLabels {
+
+    private final CollectorRegistry collectorRegistry;
+    private final String customMetricNamePrefix;
+    private final String[] systemMetricsLabelNames;
+    private final String[] systemMetricsLabels;
+
+    private String metricName;
+    private String[] userDefinedLabels;
+    private String[] userDefinedLabelNames;
+    private String helpMsg;
+
+    private Gauge gauge;
+
+    public PrometheusGaugeBuilder(CollectorRegistry collectorRegistry,
+                                  String customMetricNamePrefix,
+                                  String[] systemMetricsLabelNames,
+                                  String[] systemMetricsLabels) {
+        this.collectorRegistry = collectorRegistry;
+        this.customMetricNamePrefix = customMetricNamePrefix;
+        this.systemMetricsLabelNames = Arrays.copyOf(systemMetricsLabelNames, systemMetricsLabelNames.length);
+        this.systemMetricsLabels = Arrays.copyOf(systemMetricsLabels, systemMetricsLabels.length);
+    }
+
+    @Override
+    public GaugeBuilder name(String metricName) {
+        this.metricName = metricName;
+        return this;
+    }
+
+    @Override
+    public GaugeBuilder labelNames(String... labelNames) {
+        this.userDefinedLabelNames = labelNames;
+        return this;
+    }
+
+    @Override
+    public GaugeBuilder labels(String... labels) {
+        this.userDefinedLabels = labels;
+        return this;
+    }
+
+    @Override
+    public GaugeBuilder help(String helpMsg) {
+        this.helpMsg = helpMsg;
+        return this;
+    }
+
+    @Override
+    public GaugeBuilder gauge(Gauge gauge) {
+        this.gauge = gauge;
+        return this;
+    }
+
+    @Override
+    public Gauge register() {
+        checkArgument(this.metricName != null, "Metric name has not been set");
+        checkArgument(this.helpMsg != null, "Metric help message has not been set");
+        String[] labelNames = combineLabels(systemMetricsLabelNames, userDefinedLabelNames);
+        String[] labels = combineLabels(systemMetricsLabels, userDefinedLabels);
+        checkLabels(labelNames, labels);
+        Gauge gauge = getGauge();
+
+        io.prometheus.client.Gauge gaugeCollector = createGaugeCollector(
+                this.customMetricNamePrefix + metricName, labelNames, helpMsg);
+        collectorRegistry.register(gaugeCollector);
+        // needs to setChild because Prometheus collector implementation only collects metrics through a metric Child
+        gaugeCollector.setChild(new io.prometheus.client.Gauge.Child() {
+            @Override
+            public double get() {
+                return gauge.get();
+            }
+        }, labels);
+        return gauge;
+    }
+
+    private Gauge getGauge() {
+        if (gauge == null) {
+            return new PrometheusGaugeImpl(customMetricNamePrefix + metricName, helpMsg);
+        } else {
+            return gauge;
+        }
+    }
+
+    private io.prometheus.client.Gauge createGaugeCollector(String name, String[] labelNames, String helpMsg) {
+        return io.prometheus.client.Gauge.build()
+                .name(name)
+                .labelNames(labelNames)
+                .help(helpMsg)
+                .create();
+    }
+
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusGaugeImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusGaugeImpl.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import org.apache.pulsar.functions.api.metrics.Gauge;
+
+public class PrometheusGaugeImpl implements Gauge {
+
+    private final io.prometheus.client.Gauge gauge;
+
+    PrometheusGaugeImpl(String name, String helpMessage) {
+        this.gauge = io.prometheus.client.Gauge.build().name(name).help(helpMessage).create();
+    }
+
+    @Override
+    public void inc() {
+        gauge.inc();
+    }
+
+    @Override
+    public void inc(double amount) {
+        gauge.inc(amount);
+    }
+
+    @Override
+    public void dec() {
+        gauge.dec();
+    }
+
+    @Override
+    public void dec(double amount) {
+        gauge.dec(amount);
+    }
+
+    @Override
+    public void set(double amount) {
+        gauge.set(amount);
+    }
+
+    @Override
+    public double get() {
+        return gauge.get();
+    }
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusHistogramBuilder.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusHistogramBuilder.java
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import org.apache.pulsar.functions.api.metrics.Histogram;
+import org.apache.pulsar.functions.api.metrics.HistogramBuilder;
+
+public class PrometheusHistogramBuilder implements HistogramBuilder, MetricLabels {
+
+    private final CollectorRegistry collectorRegistry;
+    private final String customMetricNamePrefix;
+    private final String[] systemMetricsLabelNames;
+    private final String[] systemMetricsLabels;
+
+    private String metricName;
+    private String[] userDefinedLabels;
+    private String[] userDefinedLabelNames;
+    private String helpMsg;
+
+    private Histogram histogram;
+    private double[] buckets;
+
+    PrometheusHistogramBuilder(CollectorRegistry collectorRegistry,
+                               String customMetricNamePrefix,
+                               String[] systemMetricsLabelNames,
+                               String[] systemMetricsLabels) {
+        this.collectorRegistry = collectorRegistry;
+        this.customMetricNamePrefix = customMetricNamePrefix;
+        this.systemMetricsLabelNames = Arrays.copyOf(systemMetricsLabelNames, systemMetricsLabelNames.length);
+        this.systemMetricsLabels = Arrays.copyOf(systemMetricsLabels, systemMetricsLabels.length);
+    }
+
+    @Override
+    public HistogramBuilder name(String metricName) {
+        this.metricName = metricName;
+        return this;
+    }
+
+    @Override
+    public HistogramBuilder labelNames(String... labelNames) {
+        this.userDefinedLabelNames = labelNames;
+        return this;
+    }
+
+    @Override
+    public HistogramBuilder labels(String... labels) {
+        this.userDefinedLabels = labels;
+        return this;
+    }
+
+    @Override
+    public HistogramBuilder help(String helpMsg) {
+        this.helpMsg = helpMsg;
+        return this;
+    }
+
+    @Override
+    public HistogramBuilder buckets(double[] buckets) {
+        this.buckets = Arrays.copyOf(buckets, buckets.length);
+        return this;
+    }
+
+    @Override
+    public HistogramBuilder histogram(Histogram histogram) {
+        this.histogram = histogram;
+        return this;
+    }
+
+    @Override
+    public Histogram register() {
+        checkArgument(this.metricName != null, "Metric name has not been set");
+        checkArgument(this.helpMsg != null, "Metric help message has not been set");
+        String[] labelNames = combineLabels(systemMetricsLabelNames, userDefinedLabelNames);
+        String[] labels = combineLabels(systemMetricsLabels, userDefinedLabels);
+        checkLabels(labelNames, labels);
+        if (histogram == null) {
+            checkArgument(this.buckets != null, "Histogram buckets are not set");
+        } else {
+            checkArgument(this.histogram.getBuckets() != null, "Histogram buckets are not set");
+        }
+        Histogram histogram = getHistogram();
+        // no need for setChild since we use our own Histogram collector implementation
+        createHistogramCollector(customMetricNamePrefix + metricName, labelNames, labels, helpMsg, histogram)
+                .register(collectorRegistry);
+        return histogram;
+    }
+
+    private HistogramCollector createHistogramCollector(String name, String[] labelNames, String[] labels,
+                                                        String helpMsg, Histogram histogram) {
+        return new HistogramCollector(name, labelNames, labels, helpMsg, histogram);
+    }
+
+    private Histogram getHistogram() {
+        if (histogram == null) {
+            return new PrometheusHistogramImpl(customMetricNamePrefix + metricName, helpMsg, buckets);
+        } else {
+            return histogram;
+        }
+    }
+
+     // Implementing our own Histogram collector since Prometheus Histogram marks its Child's constructor as private
+    static class HistogramCollector extends Collector {
+        private final String metricName;
+        private final String[] labelsNames;
+        private final String[] labels;
+        private final String helpMsg;
+        private final Histogram histogram;
+
+        HistogramCollector(String metricName, String[] labelNames, String[] labels, String helpMsg,
+                           Histogram histogram) {
+            this.metricName = metricName;
+            this.labelsNames = labelNames;
+            this.labels = labels;
+            this.helpMsg = helpMsg;
+            this.histogram = histogram;
+        }
+
+        @Override
+        public List<MetricFamilySamples> collect() {
+            List<MetricFamilySamples.Sample> samples = new LinkedList<>();
+            double[] buckets = histogram.getBuckets();
+            double[] values = histogram.getValues();
+            List<String> labelNamesList = Arrays.asList(labelsNames);
+            List<String> labelNamesWithLe = new ArrayList<>(labelNamesList);
+            labelNamesWithLe.add("le");
+            List<String> labelValuesList = Arrays.asList(labels);
+
+            for (int i = 0; i < buckets.length; i++) {
+                List<String> labelValuesWithLe = new ArrayList<>(labelValuesList);
+                labelValuesWithLe.add(doubleToGoString(buckets[i]));
+                samples.add(new MetricFamilySamples.Sample(metricName + "_bucket", labelNamesWithLe,
+                        labelValuesWithLe, values[i]));
+            }
+            samples.add(new MetricFamilySamples.Sample(metricName + "_count", labelNamesList, labelValuesList,
+                    histogram.getCount()));
+            samples.add(new MetricFamilySamples.Sample(metricName + "_sum", labelNamesList, labelValuesList,
+                    histogram.getSum()));
+            return Collections.singletonList(new MetricFamilySamples(metricName, Type.HISTOGRAM, helpMsg, samples));
+        }
+    }
+
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusHistogramImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusHistogramImpl.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import java.util.Arrays;
+import org.apache.pulsar.functions.api.metrics.Histogram;
+
+public class PrometheusHistogramImpl implements Histogram {
+
+    private final io.prometheus.client.Histogram histogram;
+    private final double[] buckets;
+
+    PrometheusHistogramImpl(String name, String helpMessage, double[] buckets) {
+        this.buckets = buckets;
+        this.histogram = io.prometheus.client.Histogram.build()
+                .name(name)
+                .help(helpMessage)
+                .buckets(buckets)
+                .create();
+    }
+
+    @Override
+    public void observe(double value) {
+        histogram.observe(value);
+    }
+
+    @Override
+    public double[] getBuckets() {
+        return Arrays.copyOf(buckets, buckets.length);
+    }
+
+    @Override
+    public double[] getValues() {
+        return histogram.labels().get().buckets;
+    }
+
+    @Override
+    public double getSum() {
+        return histogram.labels().get().sum;
+    }
+
+    @Override
+    public double getCount() {
+        // the last Prometheus Histogram bucket is an inf bucket that essentially contains the count
+        double[] bucketValues = histogram.labels().get().buckets;
+        return bucketValues[bucketValues.length - 1];
+    }
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusMetricProviderImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusMetricProviderImpl.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import io.prometheus.client.CollectorRegistry;
+import java.util.Arrays;
+import org.apache.pulsar.functions.api.metrics.CounterBuilder;
+import org.apache.pulsar.functions.api.metrics.GaugeBuilder;
+import org.apache.pulsar.functions.api.metrics.HistogramBuilder;
+import org.apache.pulsar.functions.api.metrics.MetricProvider;
+import org.apache.pulsar.functions.api.metrics.SummaryBuilder;
+
+public class PrometheusMetricProviderImpl implements MetricProvider {
+
+    private final CollectorRegistry collectorRegistry;
+    private final String customMetricNamePrefix;
+    private final String[] systemMetricsLabelNames;
+    private final String[] systemMetricsLabels;
+
+    public PrometheusMetricProviderImpl(CollectorRegistry collectorRegistry,
+                                        String customMetricNamePrefix,
+                                        String[] systemMetricsLabelNames,
+                                        String[] systemMetricsLabels) {
+        this.collectorRegistry = collectorRegistry;
+        this.customMetricNamePrefix = customMetricNamePrefix;
+        this.systemMetricsLabels = Arrays.copyOf(systemMetricsLabels, systemMetricsLabels.length);
+        this.systemMetricsLabelNames = Arrays.copyOf(systemMetricsLabelNames, systemMetricsLabelNames.length);
+    }
+
+    @Override
+    public CounterBuilder registerCounter() {
+        return new PrometheusCounterBuilder(collectorRegistry, customMetricNamePrefix, systemMetricsLabelNames,
+                systemMetricsLabels);
+    }
+
+    @Override
+    public GaugeBuilder registerGauge() {
+        return new PrometheusGaugeBuilder(collectorRegistry, customMetricNamePrefix, systemMetricsLabelNames,
+                systemMetricsLabels);
+    }
+
+    @Override
+    public HistogramBuilder registerHistogram() {
+        return new PrometheusHistogramBuilder(collectorRegistry, customMetricNamePrefix, systemMetricsLabelNames,
+                systemMetricsLabels);
+    }
+
+    @Override
+    public SummaryBuilder registerSummary() {
+        return new PrometheusSummaryBuilder(collectorRegistry, customMetricNamePrefix, systemMetricsLabelNames,
+                systemMetricsLabels);
+    }
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusSummaryBuilder.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusSummaryBuilder.java
@@ -120,7 +120,7 @@ public class PrometheusSummaryBuilder implements SummaryBuilder, MetricLabels {
         }
     }
 
-    // Implementing our own Histogram collector since Prometheus Summary marks its Child's constructor as private
+    // Implementing our own Summary collector since Prometheus Summary marks its Child's constructor as private
     static class SummaryCollector extends Collector {
         private final String metricName;
         private final String[] labelsNames;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusSummaryBuilder.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusSummaryBuilder.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pulsar.functions.api.metrics.Summary;
+import org.apache.pulsar.functions.api.metrics.SummaryBuilder;
+
+public class PrometheusSummaryBuilder implements SummaryBuilder, MetricLabels {
+
+    private final CollectorRegistry collectorRegistry;
+    private final String customMetricNamePrefix;
+    private final String[] systemMetricsLabelNames;
+    private final String[] systemMetricsLabels;
+    private final List<Summary.Quantile> quantiles;
+
+    private String metricName;
+    private String[] userDefinedLabels;
+    private String[] userDefinedLabelNames;
+    private String helpMsg;
+
+    private Summary summary;
+
+    PrometheusSummaryBuilder(CollectorRegistry collectorRegistry,
+                             String customMetricNamePrefix,
+                             String[] systemMetricsLabelNames,
+                             String[] systemMetricsLabels) {
+        this.collectorRegistry = collectorRegistry;
+        this.customMetricNamePrefix = customMetricNamePrefix;
+        this.systemMetricsLabelNames = Arrays.copyOf(systemMetricsLabelNames, systemMetricsLabelNames.length);
+        this.systemMetricsLabels = Arrays.copyOf(systemMetricsLabels, systemMetricsLabels.length);
+        this.quantiles = new LinkedList<>();
+    }
+
+    @Override
+    public SummaryBuilder name(String metricName) {
+        this.metricName = metricName;
+        return this;
+    }
+
+    @Override
+    public SummaryBuilder labelNames(String... labelNames) {
+        this.userDefinedLabelNames = labelNames;
+        return this;
+    }
+
+    @Override
+    public SummaryBuilder labels(String... labels) {
+        this.userDefinedLabels = labels;
+        return this;
+    }
+
+    @Override
+    public SummaryBuilder help(String helpMsg) {
+        this.helpMsg = helpMsg;
+        return this;
+    }
+
+    @Override
+    public SummaryBuilder quantile(double quantile, double error) {
+        this.quantiles.add(Summary.Quantile.of(quantile, error));
+        return this;
+    }
+
+    @Override
+    public SummaryBuilder summary(Summary summary) {
+        this.summary = summary;
+        return this;
+    }
+
+    @Override
+    public Summary register() {
+        checkArgument(this.metricName != null, "Metric name has not been set");
+        checkArgument(this.helpMsg != null, "Metric help message has not been set");
+        String[] labelNames = combineLabels(systemMetricsLabelNames, userDefinedLabelNames);
+        String[] labels = combineLabels(systemMetricsLabels, userDefinedLabels);
+        checkLabels(labelNames, labels);
+        Summary summary = getSummary();
+        // no need for setChild since we use our own Summary collector implementation
+        createSummaryCollector(customMetricNamePrefix + metricName, labelNames, labels, helpMsg, summary)
+                .register(collectorRegistry);
+        return summary;
+    }
+
+    private SummaryCollector createSummaryCollector(String metricName, String[] labelNames, String[] labels,
+                                                    String helpMsg, Summary summary) {
+        return new SummaryCollector(metricName, labelNames, labels, helpMsg, summary);
+    }
+
+    private Summary getSummary() {
+        if (summary == null) {
+            return new PrometheusSummaryImpl(customMetricNamePrefix + metricName, helpMsg, quantiles);
+        } else {
+            return summary;
+        }
+    }
+
+    // Implementing our own Histogram collector since Prometheus Summary marks its Child's constructor as private
+    static class SummaryCollector extends Collector {
+        private final String metricName;
+        private final String[] labelsNames;
+        private final String[] labels;
+        private final String helpMsg;
+        private final Summary summary;
+
+        SummaryCollector(String metricName, String[] labelsNames, String[] labels, String helpMsg, Summary summary) {
+            this.metricName = metricName;
+            this.labelsNames = labelsNames;
+            this.labels = labels;
+            this.helpMsg = helpMsg;
+            this.summary = summary;
+        }
+
+        @Override
+        public List<MetricFamilySamples> collect() {
+            List<MetricFamilySamples.Sample> samples = new LinkedList<>();
+            List<String> labelNamesList = Arrays.asList(labelsNames);
+            List<String> labelNamesWithQuantile = new ArrayList<>(labelNamesList);
+            labelNamesWithQuantile.add("quantile");
+            List<String> labelValuesList = Arrays.asList(labels);
+
+            for (Map.Entry<Double, Double> q: summary.getQuantileValues().entrySet()) {
+                List<String> labelValuesWithQuantiles = new ArrayList<>(labelValuesList);
+                labelValuesWithQuantiles.add(doubleToGoString(q.getKey()));
+                samples.add(new MetricFamilySamples.Sample(metricName, labelNamesWithQuantile,
+                        labelValuesWithQuantiles, q.getValue()));
+            }
+            samples.add(new MetricFamilySamples.Sample(metricName + "_count", labelNamesList, labelValuesList,
+                    summary.getCount()));
+            samples.add(new MetricFamilySamples.Sample(metricName + "_sum", labelNamesList, labelValuesList,
+                    summary.getSum()));
+            return Collections.singletonList(new MetricFamilySamples(metricName, Type.SUMMARY, helpMsg, samples));
+        }
+    }
+
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusSummaryImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusSummaryImpl.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pulsar.functions.api.metrics.Summary;
+
+public class PrometheusSummaryImpl implements Summary {
+
+    private final List<Summary.Quantile> quantiles;
+    private final io.prometheus.client.Summary summary;
+
+    PrometheusSummaryImpl(String name, String helpMessage, List<Summary.Quantile> quantiles) {
+        this.quantiles = quantiles;
+        io.prometheus.client.Summary.Builder summaryBuilder = io.prometheus.client.Summary
+                .build()
+                .name(name)
+                .help(helpMessage);
+        for (Summary.Quantile quantile: quantiles) {
+            summaryBuilder.quantile(quantile.getQuantile(), quantile.getError());
+        }
+        summary = summaryBuilder.create();
+    }
+
+    @Override
+    public void observe(double amount) {
+        summary.observe(amount);
+    }
+
+    @Override
+    public List<Summary.Quantile> getQuantiles() {
+        return quantiles;
+    }
+
+    @Override
+    public double getSum() {
+        return summary.get().sum;
+    }
+
+    @Override
+    public double getCount() {
+        return summary.get().count;
+    }
+
+    @Override
+    public Map<Double, Double> getQuantileValues() {
+        return summary.get().quantiles;
+    }
+}

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/stats/PrometheusCounterBuilderTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/stats/PrometheusCounterBuilderTest.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import com.google.common.collect.ObjectArrays;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pulsar.functions.api.metrics.Counter;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class PrometheusCounterBuilderTest {
+
+    private static final String METRIC_PREFIX = "prefix";
+    private static final String[] SYSTEM_LABEL_NAMES = new String[]{"sysLabel1", "sysLabel2"};
+    private static final String[] SYSTEM_LABEL_VALUES = new String[]{"foo", "bar"};
+
+    private CollectorRegistry mockRegistry;
+    private PrometheusCounterBuilder builder;
+    private ArgumentCaptor<Collector> collectorCaptor;
+
+    @BeforeMethod
+    public void setup() {
+        mockRegistry = mock(CollectorRegistry.class);
+        collectorCaptor = ArgumentCaptor.forClass(Collector.class);
+        builder = new PrometheusCounterBuilder(mockRegistry, METRIC_PREFIX, SYSTEM_LABEL_NAMES, SYSTEM_LABEL_VALUES);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingName() {
+        builder.labelNames().labels().help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingHelpMsg() {
+        builder.name("name").labelNames().labels().register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesLabelValuesMismatch() {
+        builder.name("name").labelNames("label1", "label2").labels("foo").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesLabelValuesMismatch2() {
+        builder.name("name").labelNames("label1").labels("foo", "bar").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingLabelNamesButLabelValuesProvided() {
+        builder.name("name").labelNames().labels("foo", "bar").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesProvidedButMissingLabelValues() {
+        builder.name("name").labelNames("label1", "label2").labels().help("help").register();
+    }
+
+    @Test
+    public void testDefaultCounterRegistration() {
+        builder.name("name").labelNames("label1").labels("labelValue").help("help").register();
+
+        verify(mockRegistry).register(collectorCaptor.capture());
+        Collector collector = collectorCaptor.getValue();
+        assertEquals(collector.getClass(), io.prometheus.client.Counter.class);
+        io.prometheus.client.Counter promCounter = (io.prometheus.client.Counter) collector;
+
+        List<Collector.MetricFamilySamples> samples = promCounter.collect();
+        Collector.MetricFamilySamples sample = samples.get(0);
+        assertEquals(sample.name, METRIC_PREFIX + "name");
+        assertEquals(sample.help, "help");
+        List<Collector.MetricFamilySamples.Sample> sampleList = sample.samples;
+        sampleList.forEach(s -> {
+            assertEquals(s.name, METRIC_PREFIX + "name");
+            assertEquals(s.labelNames, Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1")));
+            assertEquals(s.labelValues, Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")));
+        });
+    }
+
+    @Test
+    public void testProvidedCounterRegistration() {
+        double counterValue = 123;
+        Counter mockCounter = mock(Counter.class);
+        when(mockCounter.get()).thenReturn(counterValue);
+
+        builder.name("name").labelNames("label1").labels("labelValue").help("help")
+                .counter(mockCounter).register();
+
+        verify(mockRegistry).register(collectorCaptor.capture());
+        Collector collector = collectorCaptor.getValue();
+        assertEquals(collector.getClass(), io.prometheus.client.Counter.class);
+        io.prometheus.client.Counter promCounter = (io.prometheus.client.Counter) collector;
+
+        List<Collector.MetricFamilySamples> samples = promCounter.collect();
+        Collector.MetricFamilySamples sample = samples.get(0);
+        assertEquals(sample.name, METRIC_PREFIX + "name");
+        assertEquals(sample.help, "help");
+        List<Collector.MetricFamilySamples.Sample> sampleList = sample.samples;
+        sampleList.forEach(s -> {
+            assertEquals(s.name, METRIC_PREFIX + "name");
+            assertEquals(s.labelNames, Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1")));
+            assertEquals(s.labelValues, Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")));
+            assertEquals(s.value, counterValue);
+        });
+    }
+}

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/stats/PrometheusGaugeBuilderTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/stats/PrometheusGaugeBuilderTest.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import com.google.common.collect.ObjectArrays;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pulsar.functions.api.metrics.Gauge;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class PrometheusGaugeBuilderTest {
+
+    private static final String METRIC_PREFIX = "prefix";
+    private static final String[] SYSTEM_LABEL_NAMES = new String[]{"sysLabel1", "sysLabel2"};
+    private static final String[] SYSTEM_LABEL_VALUES = new String[]{"foo", "bar"};
+
+    private CollectorRegistry mockRegistry;
+    private PrometheusGaugeBuilder builder;
+    private ArgumentCaptor<Collector> collectorCaptor;
+
+
+    @BeforeMethod
+    public void setup() {
+        mockRegistry = mock(CollectorRegistry.class);
+        collectorCaptor = ArgumentCaptor.forClass(Collector.class);
+        builder = new PrometheusGaugeBuilder(mockRegistry, METRIC_PREFIX, SYSTEM_LABEL_NAMES, SYSTEM_LABEL_VALUES);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingName() {
+        builder.labelNames().labels().help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingHelpMsg() {
+        builder.name("name").labelNames().labels().register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesLabelValuesMismatch() {
+        builder.name("name").labelNames("label1", "label2").labels("foo").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesLabelValuesMismatch2() {
+        builder.name("name").labelNames("label1").labels("foo", "bar").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingLabelNamesButLabelValuesProvided() {
+        builder.name("name").labelNames().labels("foo", "bar").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesProvidedButMissingLabelValues() {
+        builder.name("name").labelNames("label1", "label2").labels().help("help").register();
+    }
+
+    @Test
+    public void testDefaultGaugeRegistration() {
+        builder.name("name").labelNames("label1").labels("labelValue").help("help").register();
+
+        verify(mockRegistry).register(collectorCaptor.capture());
+        Collector collector = collectorCaptor.getValue();
+        assertEquals(collector.getClass(), io.prometheus.client.Gauge.class);
+        io.prometheus.client.Gauge promGauge = (io.prometheus.client.Gauge) collector;
+
+        List<Collector.MetricFamilySamples> samples = promGauge.collect();
+        Collector.MetricFamilySamples sample = samples.get(0);
+        assertEquals(sample.name, METRIC_PREFIX + "name");
+        assertEquals(sample.help, "help");
+        List<Collector.MetricFamilySamples.Sample> sampleList = sample.samples;
+        sampleList.forEach(s -> {
+            assertEquals(s.name, METRIC_PREFIX + "name");
+            assertEquals(s.labelNames, Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1")));
+            assertEquals(s.labelValues, Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")));
+        });
+    }
+
+    @Test
+    public void testProvidedGaugeRegistration() {
+        double gaugeValue = 123;
+        Gauge mockGauge = mock(Gauge.class);
+        when(mockGauge.get()).thenReturn(gaugeValue);
+
+        builder.name("name").labelNames("label1").labels("labelValue").help("help")
+                .gauge(mockGauge).register();
+
+        verify(mockRegistry).register(collectorCaptor.capture());
+        Collector collector = collectorCaptor.getValue();
+        assertEquals(collector.getClass(), io.prometheus.client.Gauge.class);
+        io.prometheus.client.Gauge promGauge = (io.prometheus.client.Gauge) collector;
+
+        List<Collector.MetricFamilySamples> samples = promGauge.collect();
+        Collector.MetricFamilySamples sample = samples.get(0);
+        assertEquals(sample.name, METRIC_PREFIX + "name");
+        assertEquals(sample.help, "help");
+        List<Collector.MetricFamilySamples.Sample> sampleList = sample.samples;
+        sampleList.forEach(s -> {
+            assertEquals(s.name, METRIC_PREFIX + "name");
+            assertEquals(s.labelNames, Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1")));
+            assertEquals(s.labelValues, Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")));
+            assertEquals(s.value, gaugeValue);
+        });
+
+    }
+
+}

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/stats/PrometheusHistogramBuilderTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/stats/PrometheusHistogramBuilderTest.java
@@ -1,0 +1,203 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import com.google.common.collect.ObjectArrays;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pulsar.functions.api.metrics.Histogram;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class PrometheusHistogramBuilderTest {
+
+    private static final String METRIC_PREFIX = "prefix";
+    private static final String[] SYSTEM_LABEL_NAMES = new String[]{"sysLabel1", "sysLabel2"};
+    private static final String[] SYSTEM_LABEL_VALUES = new String[]{"foo", "bar"};
+    private static final double[] BUCKETS = new double[]{1, 2, 3};
+
+    private CollectorRegistry mockRegistry;
+    private PrometheusHistogramBuilder builder;
+    private ArgumentCaptor<Collector> collectorCaptor;
+
+    @BeforeMethod
+    public void setup() {
+        mockRegistry = mock(CollectorRegistry.class);
+        collectorCaptor = ArgumentCaptor.forClass(Collector.class);
+        builder = new PrometheusHistogramBuilder(mockRegistry, METRIC_PREFIX, SYSTEM_LABEL_NAMES, SYSTEM_LABEL_VALUES);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingName() {
+        builder.labelNames().labels().help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingHelpMsg() {
+        builder.name("name").labelNames().labels().register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesLabelValuesMismatch() {
+        builder.name("name").labelNames("label1", "label2").labels("foo").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesLabelValuesMismatch2() {
+        builder.name("name").labelNames("label1").labels("foo", "bar").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingLabelNamesButLabelValuesProvided() {
+        builder.name("name").labelNames().labels("foo", "bar").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesProvidedButMissingLabelValues() {
+        builder.name("name").labelNames("label1", "label2").labels().help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingBuckets() {
+        builder.name("name").labelNames("label1").labels("labelValue").help("help").register();
+    }
+
+    @Test
+    public void testDefaultHistogramRegistration() {
+        builder.name("name").labelNames("label1").labels("labelValue").help("help")
+                .buckets(BUCKETS)
+                .register();
+
+        verify(mockRegistry).register(collectorCaptor.capture());
+        Collector collector = collectorCaptor.getValue();
+        assertEquals(collector.getClass(), PrometheusHistogramBuilder.HistogramCollector.class);
+        PrometheusHistogramBuilder.HistogramCollector promHistogram =
+                (PrometheusHistogramBuilder.HistogramCollector) collector;
+
+        List<Collector.MetricFamilySamples> samples = promHistogram.collect();
+        Collector.MetricFamilySamples sample = samples.get(0);
+        assertEquals(sample.name, METRIC_PREFIX + "name");
+        assertEquals(sample.help, "help");
+        List<Collector.MetricFamilySamples.Sample> sampleList = sample.samples;
+
+        // should have metric value for each bucket with a count and a sum
+        assertEquals(sampleList.size(), BUCKETS.length + 2);
+
+        // should find metric value for each bucket, with _bucket suffix for the name and le label
+        for (double bucket: BUCKETS) {
+            assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name" + "_bucket") &&
+                    CollectionUtils.isEqualCollection(s.labelNames,
+                            Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES,
+                                    new String[]{"label1", "le"}, String.class))) &&
+                    CollectionUtils.isEqualCollection(s.labelValues,
+                            Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES,
+                                    new String[]{"labelValue", String.valueOf(bucket)}, String.class)))));
+
+        }
+
+        // should have _count metric value
+        assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name" + "_count") &&
+                        CollectionUtils.isEqualCollection(s.labelNames,
+                                Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1"))) &&
+                        CollectionUtils.isEqualCollection(s.labelValues,
+                                Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")))));
+
+        // should have _sum metric value
+        assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name" + "_sum") &&
+                CollectionUtils.isEqualCollection(s.labelNames,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1"))) &&
+                CollectionUtils.isEqualCollection(s.labelValues,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")))));
+    }
+
+    @Test
+    public void testProvidedHistogramRegistration() {
+        Histogram histogram = mock(Histogram.class);
+        double histogramCount = 123;
+        double histogramSum = 321;
+        double[] histogramBucketValues = Arrays.stream(BUCKETS).map(b -> b+1).toArray();
+        when(histogram.getBuckets()).thenReturn(BUCKETS);
+        when(histogram.getCount()).thenReturn(histogramCount);
+        when(histogram.getSum()).thenReturn(histogramSum);
+        when(histogram.getValues()).thenReturn(histogramBucketValues);
+
+        builder.name("name").labelNames("label1").labels("labelValue").help("help")
+                .histogram(histogram)
+                .register();
+
+        verify(mockRegistry).register(collectorCaptor.capture());
+        Collector collector = collectorCaptor.getValue();
+        assertEquals(collector.getClass(), PrometheusHistogramBuilder.HistogramCollector.class);
+        PrometheusHistogramBuilder.HistogramCollector promHistogram =
+                (PrometheusHistogramBuilder.HistogramCollector) collector;
+
+        List<Collector.MetricFamilySamples> samples = promHistogram.collect();
+        Collector.MetricFamilySamples sample = samples.get(0);
+        assertEquals(sample.name, METRIC_PREFIX + "name");
+        assertEquals(sample.help, "help");
+        List<Collector.MetricFamilySamples.Sample> sampleList = sample.samples;
+
+        // should have metric value for each bucket with a count and a sum
+        assertEquals(sampleList.size(), BUCKETS.length + 2);
+
+        // should find metric value for each bucket, with _bucket suffix for the name and le label
+        for (int i = 0; i < BUCKETS.length; i++) {
+            double expectedBucket = BUCKETS[i];
+            double expectedBucketValue = histogramBucketValues[i];
+            assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name" + "_bucket") &&
+                    s.value == expectedBucketValue &&
+                    CollectionUtils.isEqualCollection(s.labelNames,
+                            Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES,
+                                    new String[]{"label1", "le"}, String.class))) &&
+                    CollectionUtils.isEqualCollection(s.labelValues,
+                            Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES,
+                                    new String[]{"labelValue", String.valueOf(expectedBucket)}, String.class)))));
+
+        }
+
+        // should have _count metric value
+        assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name" + "_count") &&
+                s.value == histogramCount &&
+                CollectionUtils.isEqualCollection(s.labelNames,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1"))) &&
+                CollectionUtils.isEqualCollection(s.labelValues,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")))));
+
+        // should have _sum metric value
+        assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name" + "_sum") &&
+                s.value == histogramSum &&
+                CollectionUtils.isEqualCollection(s.labelNames,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1"))) &&
+                CollectionUtils.isEqualCollection(s.labelValues,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")))));
+    }
+
+
+
+}

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/stats/PrometheusSummaryBuilderTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/stats/PrometheusSummaryBuilderTest.java
@@ -1,0 +1,203 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.instance.stats;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import com.google.common.collect.ObjectArrays;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pulsar.functions.api.metrics.Summary;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class PrometheusSummaryBuilderTest {
+
+    private static final String METRIC_PREFIX = "prefix";
+    private static final String[] SYSTEM_LABEL_NAMES = new String[]{"sysLabel1", "sysLabel2"};
+    private static final String[] SYSTEM_LABEL_VALUES = new String[]{"foo", "bar"};
+
+    private CollectorRegistry mockRegistry;
+    private PrometheusSummaryBuilder builder;
+    private ArgumentCaptor<Collector> collectorCaptor;
+    private List<Summary.Quantile> quantiles;
+
+    @BeforeMethod
+    public void setup() {
+        mockRegistry = mock(CollectorRegistry.class);
+        collectorCaptor = ArgumentCaptor.forClass(Collector.class);
+        builder = new PrometheusSummaryBuilder(mockRegistry, METRIC_PREFIX, SYSTEM_LABEL_NAMES, SYSTEM_LABEL_VALUES);
+        quantiles = new ArrayList<>();
+        quantiles.add(Summary.Quantile.of(0.5, 0.01));
+        quantiles.add(Summary.Quantile.of(0.9, 0.01));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingName() {
+        builder.labelNames().labels().help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingHelpMsg() {
+        builder.name("name").labelNames().labels().register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesLabelValuesMismatch() {
+        builder.name("name").labelNames("label1", "label2").labels("foo").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesLabelValuesMismatch2() {
+        builder.name("name").labelNames("label1").labels("foo", "bar").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMissingLabelNamesButLabelValuesProvided() {
+        builder.name("name").labelNames().labels("foo", "bar").help("help").register();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLabelNamesProvidedButMissingLabelValues() {
+        builder.name("name").labelNames("label1", "label2").labels().help("help").register();
+    }
+
+    @Test
+    public void testDefaultSummaryRegistration() {
+        builder.name("name").labelNames("label1").labels("labelValue").help("help");
+        for (Summary.Quantile quantile: quantiles) {
+            builder.quantile(quantile.getQuantile(), quantile.getError());
+        }
+        builder.register();
+
+        verify(mockRegistry).register(collectorCaptor.capture());
+        Collector collector = collectorCaptor.getValue();
+        assertEquals(collector.getClass(), PrometheusSummaryBuilder.SummaryCollector.class);
+        PrometheusSummaryBuilder.SummaryCollector promHistogram =
+                (PrometheusSummaryBuilder.SummaryCollector) collector;
+
+        List<Collector.MetricFamilySamples> samples = promHistogram.collect();
+        Collector.MetricFamilySamples sample = samples.get(0);
+        assertEquals(sample.name, METRIC_PREFIX + "name");
+        assertEquals(sample.help, "help");
+        List<Collector.MetricFamilySamples.Sample> sampleList = sample.samples;
+
+        // should have metric value for each bucket with a count and a sum
+        assertEquals(sampleList.size(), quantiles.size() + 2);
+
+        // should find metric value for each quantile with additional quantile label
+        for (Summary.Quantile quantile: quantiles) {
+            assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name") &&
+                    CollectionUtils.isEqualCollection(s.labelNames,
+                            Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES,
+                                    new String[]{"label1", "quantile"}, String.class))) &&
+                    CollectionUtils.isEqualCollection(s.labelValues,
+                            Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES,
+                                    new String[]{"labelValue", String.valueOf(quantile.getQuantile())},
+                                    String.class)))));
+        }
+
+        // should have _count metric value
+        assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name" + "_count") &&
+                CollectionUtils.isEqualCollection(s.labelNames,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1"))) &&
+                CollectionUtils.isEqualCollection(s.labelValues,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")))));
+
+        // should have _sum metric value
+        assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name" + "_sum") &&
+                CollectionUtils.isEqualCollection(s.labelNames,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1"))) &&
+                CollectionUtils.isEqualCollection(s.labelValues,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")))));
+    }
+
+    @Test
+    public void testProvidedSummaryRegistration() {
+        Summary summary = mock(Summary.class);
+        double summarySum = 123;
+        double summaryCount = 321;
+        when(summary.getSum()).thenReturn(summarySum);
+        when(summary.getCount()).thenReturn(summaryCount);
+        when(summary.getQuantiles()).thenReturn(quantiles);
+        Map<Double, Double> quantileValues = quantiles.stream()
+                .collect(Collectors.toMap(Summary.Quantile::getQuantile, q -> q.getQuantile() + 1));
+        when(summary.getQuantileValues()).thenReturn(quantileValues);
+
+        builder.name("name").labelNames("label1").labels("labelValue").summary(summary).help("help")
+                .register();
+
+        verify(mockRegistry).register(collectorCaptor.capture());
+        Collector collector = collectorCaptor.getValue();
+        assertEquals(collector.getClass(), PrometheusSummaryBuilder.SummaryCollector.class);
+        PrometheusSummaryBuilder.SummaryCollector promHistogram =
+                (PrometheusSummaryBuilder.SummaryCollector) collector;
+
+        List<Collector.MetricFamilySamples> samples = promHistogram.collect();
+        Collector.MetricFamilySamples sample = samples.get(0);
+        assertEquals(sample.name, METRIC_PREFIX + "name");
+        assertEquals(sample.help, "help");
+        List<Collector.MetricFamilySamples.Sample> sampleList = sample.samples;
+
+        // should have metric value for each bucket with a count and a sum
+        assertEquals(sampleList.size(), quantiles.size() + 2);
+
+        // should find metric value for each quantile with additional quantile label
+        for (Summary.Quantile quantile: quantiles) {
+            double expectedQuantileValue = quantileValues.get(quantile.getQuantile());
+            assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name") &&
+                    s.value == expectedQuantileValue &&
+                    CollectionUtils.isEqualCollection(s.labelNames,
+                            Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES,
+                                    new String[]{"label1", "quantile"}, String.class))) &&
+                    CollectionUtils.isEqualCollection(s.labelValues,
+                            Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES,
+                                    new String[]{"labelValue", String.valueOf(quantile.getQuantile())},
+                                    String.class)))));
+        }
+
+        // should have _count metric value
+        assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name" + "_count") &&
+                s.value == summaryCount &&
+                CollectionUtils.isEqualCollection(s.labelNames,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1"))) &&
+                CollectionUtils.isEqualCollection(s.labelValues,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")))));
+
+        // should have _sum metric value
+        assertTrue(sampleList.stream().anyMatch(s -> s.name.equals(METRIC_PREFIX + "name" + "_sum") &&
+                s.value == summarySum &&
+                CollectionUtils.isEqualCollection(s.labelNames,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_NAMES, "label1"))) &&
+                CollectionUtils.isEqualCollection(s.labelValues,
+                        Arrays.asList(ObjectArrays.concat(SYSTEM_LABEL_VALUES, "labelValue")))));
+    }
+
+}

--- a/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
+++ b/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.functions.api.metrics.MetricProvider;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
@@ -115,6 +116,11 @@ public class IOConfigUtilsTest {
         @Override
         public void recordMetric(String metricName, double value) {
 
+        }
+
+        @Override
+        public MetricProvider metricProvider() {
+            return null;
         }
 
         @Override
@@ -277,6 +283,11 @@ public class IOConfigUtilsTest {
         @Override
         public void recordMetric(String metricName, double value) {
 
+        }
+
+        @Override
+        public MetricProvider metricProvider() {
+            return null;
         }
 
         @Override

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
@@ -22,6 +22,7 @@ package org.apache.pulsar.io.kafka.sink;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.pulsar.functions.api.metrics.MetricProvider;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.KeyValue;
@@ -90,6 +91,11 @@ public class KafkaAbstractSinkTest {
             @Override
             public void recordMetric(String metricName, double value) {
 
+            }
+
+            @Override
+            public MetricProvider metricProvider() {
+                return null;
             }
 
             @Override


### PR DESCRIPTION
### Motivation

Currently Pulsar Functions have a very limited interface for tracking function metrics. `BaseContext` interface only provides the `recordMetric(String metricName, double value)` method. Under the hood `ContextImpl` saves all metric values to a prometheus Summary. It doesn’t allow the user to track different types of metrics like `Counter` `Gauge` `Histogram`. User also has no way to manipulate the labels to attach for their metrics. (Additionally since Prometheus Summary performs all the quantile calculations on the client side and offers no aggregation support, Summary is often a less preferable choice compared to Histogram)

This MR intends to introduce a new way to record metrics for Pulsar functions such that a user can decide what type of metric to track and what name, labels the metric should use. 

At the API level, a `Metric` type is introduced, which all supported metric types (implemented `Counter`, `Gauge`, `Histogram`, `Summary`) extends. Custom user metrics in Pulsar functions will be supplied and returned using this interface. In the `BaseContext` a new `MetricProvider metricProvider();` method is defined. The `MetricProvider` returns builders for each type of metric. Each metric builder allows the user to set useful data such as name, labels and help messages for the metric. Metric builders also allow users to either supply their own metric (defined through the `Metric` interface) or use the internal default implementation. To explain this design, let’s look at an example. Imagine inside a Pulsar source, with the new metrics API user could define custom metrics like this:

```java
import org.apache.pulsar.functions.api.metrics.Counter;
import org.apache.pulsar.io.core.Source;

public class DemoSource implements Source<Data> {
    
    Counter counter; 
   
    @Override
    public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
        this.counter = sourceContext.metricProvider()
            .registerCounter()
            .name("demo_counter")
            .help("helper message for counter")
            .labelNames("label1", "label2")
            .labels("foo", "bar")
            .register();
    }

    @Override
    public Record<Person> read() throws Exception {
        counter.inc();
        // ... other logic ...
    }
}
```

In this example, the user directly use an internal Counter implementation provided by the framework to track counter metrics. In certain situations, however, a user may need to proxy a metric defined in external systems or libraries. For example, imagine a Pulsar source implementation that uses some HTTP client library that internally uses its own counter to track number of requests sent, but the user of this library still wants to report this metric through the Pulsar framework. In this case, the user can register the metric through the Pulsar framework this way: 

```java
import org.apache.pulsar.functions.api.metrics.Counter;
import org.apache.pulsar.io.core.Source;

public class DemoSource implements Source<Data> {
    
    Counter counter; 
   
    @Override
    public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
        CounterProxy counterProxy = new CounterProxy(new ClientLibrary());
        this.counter = sourceContext.metricProvider()
            .registerCounter()
            .name("demo_counter")
            .help("helper message for counter")
            .labelNames("label1", "label2")
            .labels("foo", "bar")
            .counter(counterProxy) // a custom counter is provided. the value of the counter will be reported through pulsar framework
            .register();
    }

    @Override
    public Record<Person> read() throws Exception {
        counter.inc();
        // ... other logic ...
    }
    
    static class CounterProxy implements Counter {
        ClientLibrary client;

        CounterProxy(ClientLibrary client) {
            this.client = client;
        }

        @Override
        public double get() {
            // proxying the counter value from a separate system
            return this.client.getCounter().get();
        }
        // ... override other methods ...
    }
}
```

With this new metrics API, registered custom user metrics would be reported on [`http://localhost:8080/metrics/`](http://localhost:8080/metrics/) like this:

```
# HELP pulsar_source_user_metric_demo_counter helper message for counter"
# TYPE pulsar_source_user_metric_demo_counter counter
pulsar_source_user_metric_demo_counter{tenant="public",namespace="public/default",name="pulsar-io-datagen",instance_id="0",cluster="standalone",fqfn="public/default/pulsar-io-datagen",label1="foo",} 259.0
```

Internally, since Pulsar is already using Prometheus as its underlying metrics system, registered user custom metrics will be reported through Prometheus. Metrics collection is either achieved by using existing Prometheus `io.prometheus.client.Collector` (`Counter` `Gauge`) implementation or providing our own collector implementation (`Histogram`, `Summary`). 

### Modifications

This MR contains lots of changes in the `pulsar-functions` module, but the idea behind is pretty simple as described above.

###  Verifying this change

All new metric APIs and implementations are covered by unit tests. 

Also manually verified the system works end to end by:

1. Adding and registering an example `Counter` and `Summary` in `DataGeneratorSource`
2. Starting up a local standalone Pulsar cluster by: `bin/pulsar standalone` 
3. Creating a `DataGeneratorSource` by: `bin/pulsar-admin sources create`
4. After the source is successfully running for a while, hit [`http://localhost:8080/metrics/`](http://localhost:8080/metrics/) to verify the registered metrics have been reported correctly:

```
# TYPE pulsar_source_system_exception gauge
# HELP pulsar_source_user_metric_records_counter counter for records read
# TYPE pulsar_source_user_metric_records_counter counter
pulsar_source_user_metric_records_counter{tenant="public",namespace="public/default",name="pulsar-io-datagen",instance_id="0",cluster="standalone",fqfn="public/default/pulsar-io-datagen",label1="foo",} 1557.0

# HELP pulsar_source_user_metric_runtime runtime latency
# TYPE pulsar_source_user_metric_runtime summary
pulsar_source_user_metric_runtime{tenant="public",namespace="public/default",name="pulsar-io-datagen",instance_id="0",cluster="standalone",fqfn="public/default/pulsar-io-datagen",label1="foo",label2="bar",quantile="0.5",} 0.513479111265846
pulsar_source_user_metric_runtime{tenant="public",namespace="public/default",name="pulsar-io-datagen",instance_id="0",cluster="standalone",fqfn="public/default/pulsar-io-datagen",label1="foo",label2="bar",quantile="0.9",} 0.8995500765220129
pulsar_source_user_metric_runtime{tenant="public",namespace="public/default",name="pulsar-io-datagen",instance_id="0",cluster="standalone",fqfn="public/default/pulsar-io-datagen",label1="foo",label2="bar",quantile="0.99",} 0.9922919051399153
pulsar_source_user_metric_runtime{tenant="public",namespace="public/default",name="pulsar-io-datagen",instance_id="0",cluster="standalone",fqfn="public/default/pulsar-io-datagen",label1="foo",label2="bar",quantile="0.999",} 0.9998848111911606
pulsar_source_user_metric_runtime_count{tenant="public",namespace="public/default",name="pulsar-io-datagen",instance_id="0",cluster="standalone",fqfn="public/default/pulsar-io-datagen",label1="foo",label2="bar",} 1557.0
pulsar_source_user_metric_runtime_sum{tenant="public",namespace="public/default",name="pulsar-io-datagen",instance_id="0",cluster="standalone",fqfn="public/default/pulsar-io-datagen",label1="foo",label2="bar",} 792.5118673696929
```

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

- Dependencies (does it add or upgrade a dependency): no
- The public API: yes
- The schema: no
- The default values of configurations: no
- The wire protocol: no
- The rest endpoints: no
- The admin cli options: no
- Anything that affects deployment: no

### Documentation

New documentation could be added for showing how to register Pulsar function metrics through the framework using the new API